### PR TITLE
Añadir dto Users

### DIFF
--- a/src/main/java/com/codigojava/biblioteca/dtos/UsersDto.java
+++ b/src/main/java/com/codigojava/biblioteca/dtos/UsersDto.java
@@ -1,0 +1,40 @@
+package com.codigojava.biblioteca.dtos;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class UsersDto {
+
+   private Integer userId;
+
+   private String fullname;
+
+   private String dni;
+
+   private String address;
+
+   private String city;
+
+   private String province;
+
+   private String postalCode;
+
+   private String country;
+
+   private String phone;
+
+   private String email;
+
+   private String password;
+
+   private Date registrationDate;
+
+   private boolean userDrop;
+
+   private Integer daysDisciplinary;
+   
+   private String role;
+
+}


### PR DESCRIPTION
Se crea la clase dtos UsersDto.java.

No hay restricción y se muestra todos los campos ya que esta dto tiene una función de soporte para los trabajadores de la biblioteca.