### PR TITLE
Añadir mapper users

### DIFF
--- a/src/main/java/com/codigojava/biblioteca/mappers/UsersMapper.java
+++ b/src/main/java/com/codigojava/biblioteca/mappers/UsersMapper.java
@@ -1,0 +1,28 @@
+package com.codigojava.biblioteca.mappers;
+
+import com.codigojava.biblioteca.dataholders.UsersCreatedDh;
+import com.codigojava.biblioteca.dataholders.UsersUpdatedDh;
+import com.codigojava.biblioteca.dtos.UsersDto;
+import com.codigojava.biblioteca.entities.UsersEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface UsersMapper {
+
+    UsersEntity asEntity(UsersCreatedDh usersDh);
+
+    void updateEntityFromDh(UsersUpdatedDh usersDh, @MappingTarget UsersEntity entity);
+
+    List<UsersEntity> asEntityList(List<UsersCreatedDh> usersDhList);
+
+    UsersDto asDto(UsersEntity users);
+
+    List<UsersDto> asDtoList(List<UsersEntity> usersList);
+
+}


### PR DESCRIPTION
Se crea la clase **UsersMapper.java**.

Para la creación de un objeto UsersEntity con los datos que venga del objeto UsersUpdatedDh se tendrá en cuenta que solo rellenara los campos diferentes a null para evitar en el operación Updated sobrescriba un dato con null.