### PR TITLE
Update mapper categories

### DIFF
--- a/src/main/java/com/codigojava/biblioteca/mappers/CategoriesMapper.java
+++ b/src/main/java/com/codigojava/biblioteca/mappers/CategoriesMapper.java
@@ -5,15 +5,19 @@ import com.codigojava.biblioteca.dataholders.CategoriesUpdatedDh;
 import com.codigojava.biblioteca.dtos.CategoriesDto;
 import com.codigojava.biblioteca.entities.CategoriesEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
 public interface CategoriesMapper {
 
     CategoriesEntity asEntity(CategoriesCreatedDh categoriesDh);
 
-    CategoriesEntity asEntity(CategoriesUpdatedDh categoriesDh);
+    void updateEntityFromDh(CategoriesUpdatedDh categoriesDh, @MappingTarget CategoriesEntity entity);
 
     List<CategoriesEntity> asEntityList(List<CategoriesCreatedDh> categoriesDhList);
 

--- a/src/main/java/com/codigojava/biblioteca/services/CategoriesServiceImp.java
+++ b/src/main/java/com/codigojava/biblioteca/services/CategoriesServiceImp.java
@@ -114,9 +114,10 @@ public class CategoriesServiceImp implements CategoriesService {
         }
 
         try {
-            existingCategory.setNameCategory(categoriesDh.getNameCategory());
-            existingCategory.setSubtopicCategory(categoriesDh.getSubtopicCategory());
+            categoriesMapper.updateEntityFromDh(categoriesDh, existingCategory);
+
             final CategoriesEntity updatedCategory = this.categoriesRepository.save(existingCategory);
+
             return this.categoriesMapper.asDto(updatedCategory);
 
         } catch (Exception e) {


### PR DESCRIPTION
# Acciones realizadas.

- Añadir el método void updateEntityFromDh(CategoriesUpdatedDh categoriesDh, @MappingTarget CategoriesEntity entity) en la clase dataholder **CategoriesDh.java**.

- Usar el método updateEntityFromDh de la clase CategoriesDh.java en el método updateById() de la clase service **CategoriesServiceImp.java**.

- Se realiza las pruebas de funcionalidad en PUT localhost:9800/categories/id/:id permitiendo actualizaciones sin el campo subtopicCategory.