### PR TITLE
Creando endpoint PUT, DELETE para Histories

### DIFF
--- a/src/main/java/com/codigojava/biblioteca/controllers/HistoriesController.java
+++ b/src/main/java/com/codigojava/biblioteca/controllers/HistoriesController.java
@@ -1,6 +1,7 @@
 package com.codigojava.biblioteca.controllers;
 
 import com.codigojava.biblioteca.dataholders.HistoriesRecordDh;
+import com.codigojava.biblioteca.dataholders.HistoriesUpdatedRecordDh;
 import com.codigojava.biblioteca.dtos.HistoriesDto;
 import com.codigojava.biblioteca.exceptions.DhValidationException;
 import com.codigojava.biblioteca.services.HistoriesService;
@@ -56,4 +57,25 @@ public class HistoriesController {
     public ResponseEntity<HistoriesDto> save(@Validated @RequestBody final HistoriesRecordDh historiesDh) {
         return ResponseEntity.ok(this.historiesService.save(historiesDh));
     }
+
+    @PutMapping(value = "/id/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<HistoriesDto> updateById(@Validated @PathVariable final Integer id, @Validated @RequestBody final HistoriesUpdatedRecordDh historiesDh) {
+
+        if (id == null || id <= 0) {
+            throw new DhValidationException("id", "The id must be a positive integer greater than 0");
+        }
+
+        return ResponseEntity.ok(this.historiesService.updateById(id, historiesDh));
+    }
+
+    @DeleteMapping(value = "/id/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Boolean> deleteById(@Validated @PathVariable final Integer id) {
+
+        if (id == null || id <= 0) {
+            throw new DhValidationException("id", "The id must be a positive integer greater than 0");
+        }
+
+        return ResponseEntity.ok(this.historiesService.deleteById(id));
+    }
+
 }

--- a/src/main/java/com/codigojava/biblioteca/dataholders/HistoriesUpdatedRecordDh.java
+++ b/src/main/java/com/codigojava/biblioteca/dataholders/HistoriesUpdatedRecordDh.java
@@ -6,7 +6,10 @@ import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
-public record HistoriesRecordDh(
+public record HistoriesUpdatedRecordDh(
+
+        @Min(value = 1, message = "History id must be a number positive")
+        Integer historyId,
 
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate dateFeedback,
@@ -16,5 +19,5 @@ public record HistoriesRecordDh(
 
         @Min(value = 1, message = "Loan id for history must be a number positive")
         Integer loanId
-)
-{}
+
+) {}

--- a/src/main/java/com/codigojava/biblioteca/mappers/HistoriesMapper.java
+++ b/src/main/java/com/codigojava/biblioteca/mappers/HistoriesMapper.java
@@ -1,10 +1,12 @@
 package com.codigojava.biblioteca.mappers;
 
 import com.codigojava.biblioteca.dataholders.HistoriesRecordDh;
+import com.codigojava.biblioteca.dataholders.HistoriesUpdatedRecordDh;
 import com.codigojava.biblioteca.dtos.HistoriesDto;
 import com.codigojava.biblioteca.entities.HistoriesEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
 import java.util.List;
@@ -18,6 +20,8 @@ public interface HistoriesMapper {
     HistoriesEntity asEntity(HistoriesRecordDh historyDh);
 
     List<HistoriesEntity> asEntityList(List<HistoriesRecordDh> historiesDh);
+
+    void updateEntityFromDh(HistoriesUpdatedRecordDh historiesDh, @MappingTarget HistoriesEntity historiesEntity);
 
     @Mapping(target = "loanId", source = "loan.loanId")
     HistoriesDto asDto(HistoriesEntity historiesEntity);

--- a/src/main/java/com/codigojava/biblioteca/services/HistoriesService.java
+++ b/src/main/java/com/codigojava/biblioteca/services/HistoriesService.java
@@ -1,6 +1,7 @@
 package com.codigojava.biblioteca.services;
 
 import com.codigojava.biblioteca.dataholders.HistoriesRecordDh;
+import com.codigojava.biblioteca.dataholders.HistoriesUpdatedRecordDh;
 import com.codigojava.biblioteca.dtos.HistoriesDto;
 
 import java.util.List;
@@ -14,5 +15,9 @@ public interface HistoriesService {
     List<HistoriesDto> findByLoanId(Integer id);
 
     HistoriesDto save(HistoriesRecordDh historiesDh);
+
+    HistoriesDto updateById(Integer id, HistoriesUpdatedRecordDh historiesDh);
+
+    Boolean deleteById(Integer id);
 
 }

--- a/src/main/java/com/codigojava/biblioteca/services/HistoriesServiceImp.java
+++ b/src/main/java/com/codigojava/biblioteca/services/HistoriesServiceImp.java
@@ -1,8 +1,10 @@
 package com.codigojava.biblioteca.services;
 
 import com.codigojava.biblioteca.dataholders.HistoriesRecordDh;
+import com.codigojava.biblioteca.dataholders.HistoriesUpdatedRecordDh;
 import com.codigojava.biblioteca.dtos.HistoriesDto;
 import com.codigojava.biblioteca.entities.HistoriesEntity;
+import com.codigojava.biblioteca.exceptions.BdInternalException;
 import com.codigojava.biblioteca.exceptions.BdNotFoundException;
 import com.codigojava.biblioteca.exceptions.BdNotSaveException;
 import com.codigojava.biblioteca.mappers.HistoriesMapper;
@@ -82,6 +84,48 @@ public class HistoriesServiceImp implements HistoriesService {
         } catch (Exception e) {
             log.warn("Save for histories - Error saving history. Possible cause: {}", e.getMessage());
             throw new BdNotSaveException("POST - Error save history.  Possible cause: BD inconsistency or internal failure.");
+        }
+    }
+
+    @Override
+    public HistoriesDto updateById(final Integer id, final HistoriesUpdatedRecordDh historiesDh) {
+        final HistoriesEntity existingHistory = this.historiesRepository.findById(id)
+                .orElseThrow(() -> new BdNotFoundException("PUT - No history found with id: " + id));
+
+        if (historiesDh.historyId() == null || historiesDh.historyId() != id) {
+            throw new BdNotSaveException(
+                    "PUT - Parameters are incorrect:" +
+                            " historyId " + historiesDh.historyId() + " is different from id " + id );
+        }
+
+        try {
+            historiesMapper.updateEntityFromDh(historiesDh, existingHistory);
+
+            final HistoriesEntity updatedHistory = this.historiesRepository.save(existingHistory);
+
+            return this.historiesMapper.asDto(updatedHistory);
+
+        } catch (Exception e) {
+            throw new BdInternalException(
+                    "PUT - Error saving history. Possible cause: DB inconsistency or internal failure."
+            );
+        }
+    }
+
+    @Override
+    public Boolean deleteById(final Integer id) {
+        final Optional<HistoriesEntity> existingHistories = this.historiesRepository.findById(id);
+
+        if (existingHistories.isEmpty()) {
+            throw new BdNotFoundException("DELETE - No histories found with id: " + id);
+        }
+
+        try {
+            this.historiesRepository.deleteById(id);
+            return true;
+        } catch (Exception e) {
+            log.warn("Delete for histories - Error deleting history. Possible cause: {}", e.getMessage());
+            throw new BdInternalException( "DELETE - Error deleting history. Possible cause: table missing or DB inconsistency." );
         }
     }
 


### PR DESCRIPTION
Se ha creado los siguientes endpoints para histories:

- PUT localhost:9800/histories/id/{id}  El método empleado es updateById() en service y controller, añadido el método updateEntityFromDh() en Mapper.

- DELETE localhost:9800/histories/id/{id} Método implementado deleteById() en service y controller

- Paso las pruebas realizada en Postman.

- Validado que da aviso de error en caso de poner mal los datos en la cadena de JSON y en la URL.


