### PR TITLE
feat:Asignar roles a endpoints configurando la seguridad

### DIFF
--- a/src/main/java/com/codigojava/biblioteca/entities/UsersEntity.java
+++ b/src/main/java/com/codigojava/biblioteca/entities/UsersEntity.java
@@ -85,7 +85,7 @@ public class UsersEntity implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
     }
 
     @Override

--- a/src/main/java/com/codigojava/biblioteca/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/codigojava/biblioteca/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.codigojava.biblioteca.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException ex) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.getWriter().write("""
+                {
+                    "status": 403,
+                    "error": "Forbidden",
+                    "message": "You don't have permission to access this resource",
+                    "path": "%s"
+                }
+                """.formatted(request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/codigojava/biblioteca/security/SecurityConfiguration.java
+++ b/src/main/java/com/codigojava/biblioteca/security/SecurityConfiguration.java
@@ -30,6 +30,9 @@ public class SecurityConfiguration {
     @Autowired
     private RoleHierarchy roleHierarchy;
 
+    @Autowired
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
+
     @Bean
     static RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl.withDefaultRolePrefix()
@@ -128,7 +131,10 @@ public class SecurityConfiguration {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .exceptionHandling(ex -> ex.authenticationEntryPoint(securityEntryPoint))
+                .exceptionHandling(ex -> {
+                        ex.authenticationEntryPoint(securityEntryPoint);
+                        ex.accessDeniedHandler(customAccessDeniedHandler);
+                })
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);
     }
 

--- a/src/main/java/com/codigojava/biblioteca/security/SecurityConfiguration.java
+++ b/src/main/java/com/codigojava/biblioteca/security/SecurityConfiguration.java
@@ -3,14 +3,19 @@ package com.codigojava.biblioteca.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authorization.AuthorityAuthorizationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
@@ -22,23 +27,112 @@ public class SecurityConfiguration {
     @Autowired
     public SecurityEntryPoint securityEntryPoint;
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    @Autowired
+    private RoleHierarchy roleHierarchy;
 
-        return http.csrf(csrf-> csrf.disable())
-                .sessionManagement(sm-> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    @Bean
+    static RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+                .role("ADMIN").implies("SUPPORT")
+                .role("SUPPORT").implies("USER")
+                .build();
+    }
+
+    // Helper reutilizable
+    private AuthorityAuthorizationManager<RequestAuthorizationContext> withRole(String role) {
+        var manager = AuthorityAuthorizationManager.<RequestAuthorizationContext>hasRole(role);
+        manager.setRoleHierarchy(roleHierarchy);
+        return manager;
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
+
+        applyCommonConfig(http);
+
+        return http
+                .securityMatcher("/users/**")
                 .authorizeHttpRequests(req->{
-                    req.requestMatchers(HttpMethod.POST,"/auth/register").permitAll();
-                    req.requestMatchers(HttpMethod.POST,"/auth/login").permitAll();
+                    req.requestMatchers(HttpMethod.GET,"/users/id/**").access(withRole("USER"));;
+                    req.requestMatchers(HttpMethod.DELETE, "/users/drop/**").access(withRole("USER"));
+                    req.requestMatchers(HttpMethod.POST,"/users").access(withRole("ADMIN"));
+                    req.requestMatchers(HttpMethod.GET, "/users","/users/name/**").access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.PUT,"/users/id/**").access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.DELETE, "/users/id/**").access(withRole("ADMIN"));
                     req.anyRequest().authenticated();
                 })
-                .exceptionHandling(ex -> ex.authenticationEntryPoint(securityEntryPoint))
-                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
-
-
-
     }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain loansSecurityFilterChain(HttpSecurity http) throws Exception {
+
+        applyCommonConfig(http);
+
+        return http
+                .securityMatcher("/loans/**")
+                .authorizeHttpRequests(req->{
+                    req.requestMatchers(HttpMethod.GET,"/loans/user/**", "/loans/isbn/**").access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.GET,"/loans" ,"/loans/id/**").access(withRole("USER"));
+                    req.requestMatchers(HttpMethod.POST,"/loans" ).access(withRole("USER"));
+                    req.requestMatchers(HttpMethod.PUT,"/loans/id/**").access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.DELETE,"/loans/id/**").access(withRole("SUPPORT"));
+                    req.anyRequest().denyAll();
+                })
+                .build();
+    }
+
+    @Bean
+    @Order(3)
+    public SecurityFilterChain historiesSecurityFilterChain(HttpSecurity http) throws Exception {
+
+        applyCommonConfig(http);
+
+        return http
+                .securityMatcher("/histories/**")
+                .authorizeHttpRequests(req->{
+                    req.requestMatchers(HttpMethod.GET,"/histories","/histories/id/**","/histories/loan/**").access(withRole("USER"));
+                    req.requestMatchers(HttpMethod.POST,"/histories" ).access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.PUT,"/histories/id/**").access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.DELETE,"/histories/id/**").access(withRole("SUPPORT"));
+                    req.anyRequest().denyAll();
+                })
+                .build();
+    }
+
+    @Bean
+    @Order(4)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        applyCommonConfig(http);
+
+        return http
+                .securityMatcher("/books/**","/authors/**", "/publishers/**", "/categories/**")
+                .authorizeHttpRequests(req->{
+                    req.requestMatchers(HttpMethod.GET,"/books/public/**").permitAll();
+                    req.requestMatchers(HttpMethod.GET).authenticated();
+                    req.requestMatchers(HttpMethod.POST).access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.PUT).access(withRole("SUPPORT"));
+                    req.requestMatchers(HttpMethod.DELETE).access(withRole("ADMIN"));
+                    req.anyRequest().denyAll();
+                })
+                .build();
+    }
+
+
+
+    // Configuración común extraída aquí para no repetir
+    private void applyCommonConfig(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(securityEntryPoint))
+                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {


### PR DESCRIPTION
-Agregué diferentes filterCHains basados en las reglas dadas para los permisos de endpoints
-Agregué metodos reutilizables para no repetir codigo en cada metodo
-Agregué un metodo RoleHierarchy para herencia de roles
-Agregué un helper para usar este RoleHierarchy en cada filterchain
-Fix: Corregí "ROLE" + role.name() → "ROLE_" + role.name() en UsersEntity.getAuthorities() para que Spring Security reconozca correctamente los roles.